### PR TITLE
Support for handling comment conflicts. Common cases are handled, tho…

### DIFF
--- a/src/main/java/conflerge/ConflergeUtil.java
+++ b/src/main/java/conflerge/ConflergeUtil.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 /**
- * 
+ * Globally useful definitions.
  */
 public class ConflergeUtil {
     
@@ -12,6 +12,31 @@ public class ConflergeUtil {
      * The number of expected command-line arguments.
      */
     static final int NUM_ARGS = 4;
+    
+    /**
+     * true iff a conflict has been detected.
+     */
+    public static boolean conflict = false;
+    
+    /**
+     * true iff a conflict has been detected in comments.
+     */
+    public static boolean commentConflict = false;
+    
+    /**
+     * Reports the detection of a conflict.
+     */
+    public static void reportConflict() {
+        ConflergeUtil.conflict = true;
+    }
+    
+    /**
+     * Reports the detection of a conflict in comments.
+     */
+    public static void reportCommentConflict() {
+        ConflergeUtil.commentConflict = true;
+    }
+    
     
     /**
      * Writes mergedFile to mergedFileDest.
@@ -24,7 +49,9 @@ public class ConflergeUtil {
             writer.println(fileContents);
             writer.close();
             System.out.println("SUCCESS");
-            
+            if (commentConflict) {
+                System.out.println("Conflicting comments remaining: please resolve these manually.");
+            }            
         } catch (IOException e) {
             fail("Unexpected error writing to file");
         }

--- a/src/main/java/conflerge/tree/DiffResult.java
+++ b/src/main/java/conflerge/tree/DiffResult.java
@@ -4,10 +4,12 @@ import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.comments.Comment;
 
 import conflerge.tree.ast.NodeListWrapper;
 
@@ -35,6 +37,11 @@ public class DiffResult {
      * Map from nodes in A -> altered modifiers in B.
      */
     public final IdentityHashMap<Node, EnumSet<Modifier>> modifiers;
+    
+    /**
+     * Mapping of nodes aligned in A -> their comments modified in B.
+     */
+    public final IdentityHashMap<Node, Optional<Comment>> comments;
       
     /**
      * @param deletes
@@ -45,12 +52,14 @@ public class DiffResult {
     public DiffResult(Set<Node> deletes, 
                       IdentityHashMap<Node, Node> replaces,
                       IdentityHashMap<Node, EnumSet<Modifier>> modifiers,
+                      IdentityHashMap<Node, Optional<Comment>> comments,
                       IdentityHashMap<NodeListWrapper, Map<Integer, List<Node>>> listInserts) {
         
         this.deletes = deletes;
         this.replaces = replaces;
         this.listInserts = listInserts;
         this.modifiers = modifiers;
+        this.comments = comments;
     }
       
     /**

--- a/src/main/java/conflerge/tree/TreeMerger.java
+++ b/src/main/java/conflerge/tree/TreeMerger.java
@@ -13,6 +13,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.utils.Pair;
 
+import conflerge.ConflergeUtil;
 import conflerge.tree.visitor.MergeVisitor;
 import conflerge.tree.visitor.NodeListUnwrapperVisitor;
 import conflerge.tree.visitor.NodeListWrapperVisitor;
@@ -30,11 +31,6 @@ public class TreeMerger {
     private Node base;
     private Node local;
     private Node remote;
-    
-    /**
-     * true iff a conflict has been detected.
-     */
-    public static boolean conflict;
     
     /**
      * The imports that will be included in the resulting merge, if successful.
@@ -75,12 +71,13 @@ public class TreeMerger {
         DiffResult localDiff = new TreeDiffer(base, local).diff();
         DiffResult remoteDiff = new TreeDiffer(base, remote).diff();
         
-        conflict = false;
+        ConflergeUtil.conflict = false;
+        ConflergeUtil.commentConflict = false;
         
         Pair<DiffResult, DiffResult> diffs = new Pair<>(localDiff, remoteDiff);
         base.accept(new MergeVisitor(), diffs);   
         
-        if (conflict) {
+        if (ConflergeUtil. conflict) {
             return null;
         }
         
@@ -89,13 +86,6 @@ public class TreeMerger {
         addImports((CompilationUnit) base, imports);
         
         return base;
-    }
-    
-    /**
-     * Reports the detection of a conflict.
-     */
-    public static void reportConflict() {
-        conflict = true;
     }
     
     /**

--- a/src/main/java/conflerge/tree/visitor/ConflictDetectionVisitor.java
+++ b/src/main/java/conflerge/tree/visitor/ConflictDetectionVisitor.java
@@ -90,8 +90,8 @@ import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.type.WildcardType;
 import com.github.javaparser.ast.visitor.Visitable;
 
+import conflerge.ConflergeUtil;
 import conflerge.tree.DiffResult;
-import conflerge.tree.TreeMerger;
 import conflerge.tree.ast.NodeListWrapper;
 
 /**
@@ -114,7 +114,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     public Visitable visit(NodeList n, DiffResult args) {
         if (n instanceof NodeListWrapper) {
             if (args.listInserts.containsKey(n)) {
-                TreeMerger.reportConflict();
+                ConflergeUtil.reportConflict();
                 return n;
             }
             NodeList nl = ((NodeListWrapper) n).nodeList; 
@@ -138,7 +138,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final AnnotationDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -147,7 +147,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final AnnotationMemberDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -156,7 +156,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ArrayAccessExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -165,7 +165,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ArrayCreationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -174,7 +174,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ArrayInitializerExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -183,7 +183,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final AssertStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -192,7 +192,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final AssignExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -201,7 +201,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final BinaryExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -210,7 +210,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final BlockStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -219,7 +219,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final BooleanLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -228,7 +228,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final BreakStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -237,7 +237,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final CastExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -246,7 +246,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final CatchClause n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -255,7 +255,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final CharLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -264,7 +264,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ClassExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -273,7 +273,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ClassOrInterfaceDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -282,7 +282,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ClassOrInterfaceType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -291,7 +291,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final CompilationUnit n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -300,7 +300,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ConditionalExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -309,7 +309,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ConstructorDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -318,7 +318,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ContinueStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -327,7 +327,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final DoStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -336,7 +336,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final DoubleLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -345,7 +345,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final EmptyMemberDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -354,7 +354,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final EmptyStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -363,7 +363,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final EnclosedExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -372,7 +372,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final EnumConstantDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -381,7 +381,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final EnumDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -390,7 +390,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ExplicitConstructorInvocationStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -399,7 +399,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ExpressionStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -408,7 +408,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final FieldAccessExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -417,7 +417,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final FieldDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -426,7 +426,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ForeachStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -435,7 +435,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ForStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -444,7 +444,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final IfStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -453,7 +453,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final InitializerDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -462,7 +462,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final InstanceOfExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -471,7 +471,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final IntegerLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -480,7 +480,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final JavadocComment n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -489,7 +489,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final LabeledStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -498,7 +498,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final LongLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -507,7 +507,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final MarkerAnnotationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -516,7 +516,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final MemberValuePair n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -525,7 +525,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final MethodCallExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -534,7 +534,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final MethodDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -543,7 +543,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final NameExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -552,7 +552,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final NormalAnnotationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -561,7 +561,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final NullLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -570,7 +570,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ObjectCreationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -579,7 +579,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final PackageDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -588,7 +588,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final Parameter n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -597,7 +597,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final Name n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -606,7 +606,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final PrimitiveType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -615,7 +615,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(SimpleName n, DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -624,7 +624,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(ArrayType n, DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -633,7 +633,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(ArrayCreationLevel n, DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -642,7 +642,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final IntersectionType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -651,7 +651,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final UnionType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -660,7 +660,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ReturnStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -669,7 +669,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final SingleMemberAnnotationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -678,7 +678,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final StringLiteralExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -687,7 +687,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final SuperExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -696,7 +696,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final SwitchEntryStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -705,7 +705,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final SwitchStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -714,7 +714,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final SynchronizedStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -723,7 +723,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ThisExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -732,7 +732,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final ThrowStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -741,7 +741,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final TryStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -750,7 +750,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final LocalClassDeclarationStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -759,7 +759,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final TypeParameter n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -768,7 +768,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final UnaryExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -777,7 +777,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final UnknownType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -786,7 +786,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final VariableDeclarationExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -795,7 +795,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final VariableDeclarator n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -804,7 +804,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final VoidType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -813,7 +813,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final WhileStmt n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -822,7 +822,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final WildcardType n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -831,7 +831,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final LambdaExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -840,7 +840,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final MethodReferenceExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -849,7 +849,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final TypeExpr n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -858,7 +858,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Node visit(final ImportDeclaration n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -867,7 +867,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final BlockComment n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);
@@ -876,7 +876,7 @@ public class ConflictDetectionVisitor extends ModifierVisitor<DiffResult> {
     @Override
     public Visitable visit(final LineComment n, final DiffResult arg) {
         if (arg.replaced(n) || arg.deleted(n) || arg.modifiers.containsKey(n)) {
-            TreeMerger.reportConflict();
+            ConflergeUtil.reportConflict();
             return n;
         }
         return super.visit(n, arg);

--- a/src/test/java/conflerge/token/TestTokens.java
+++ b/src/test/java/conflerge/token/TestTokens.java
@@ -1,7 +1,7 @@
 package conflerge.token;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -16,6 +16,7 @@ import org.junit.Test;
 import com.github.javaparser.JavaToken;
 
 import conflerge.ConflergeTokens;
+import conflerge.ConflergeUtil;
 
 /**
  * System tests for Conflerge's token merging.
@@ -63,6 +64,8 @@ public class TestTokens {
         writeFile(BASE, base);
         writeFile(LOCAL, local);
         writeFile(REMOTE, remote);
+        ConflergeUtil.commentConflict = false;
+        ConflergeUtil.conflict = false;
         ConflergeTokens.main(new String[] { BASE, LOCAL, REMOTE, MERGED });
     }
     
@@ -144,6 +147,14 @@ public class TestTokens {
         String l = "class Baz { }";
         String r = "class Bar { }";
         checkMergeFails(b, l, r);
+    }
+    
+    @Test
+    public void testCommentConflict() {
+        String b = "class Foo { int x; }";
+        String l = "class Foo { /* commentA */ int x;  }";
+        String r = "class Foo { /* commentB */ int x; }";
+        checkMergeSucceeds(b, l, r, "class Foo { /* >>>LOCAL:  commentA \n<<< REMOTE:  commentB */ int x; }");
     }
 
 }

--- a/src/test/java/conflerge/tree/Test3WayConflict.java
+++ b/src/test/java/conflerge/tree/Test3WayConflict.java
@@ -8,6 +8,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.utils.Pair;
 
+import conflerge.ConflergeUtil;
 import conflerge.tree.visitor.MergeVisitor;
 import conflerge.tree.visitor.NodeListUnwrapperVisitor;
 import conflerge.tree.visitor.NodeListWrapperVisitor;
@@ -30,12 +31,12 @@ public class Test3WayConflict {
         DiffResult localDiff = new TreeDiffer(base, local).diff();
         DiffResult remoteDiff = new TreeDiffer(base, remote).diff();
         
-        TreeMerger.conflict = false;
+        ConflergeUtil.conflict = false;
         
         base.accept(new MergeVisitor(), new Pair<DiffResult, DiffResult>(localDiff, remoteDiff));   
         base.accept(new NodeListUnwrapperVisitor(), null); 
         
-        assertEquals(TreeMerger.conflict, conflict);
+        assertEquals(ConflergeUtil.conflict, conflict);
         
     }
     


### PR DESCRIPTION
…ugh there are some remaining situations where Conflerge could discard a comment: for example, if a comment is modified in a deleted subtree. There is no obvious, elegant way to handle this, so I'll consider it an acceptable sacrifice for the time being.